### PR TITLE
Add an extension point for VAAPI Intel driver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,8 @@ SUBST_FILES=org.freedesktop.Sdk.json \
 	os-release issue issue.net \
 	org.freedesktop.Sdk.appdata.xml org.freedesktop.Platform.appdata.xml \
 	org.freedesktop.Platform.GL.mesa-git.json \
-	org.freedesktop.Sdk.Extension.gfortran62.json
+	org.freedesktop.Sdk.Extension.gfortran62.json \
+	org.freedesktop.Platform.VAAPI.Intel.json
 
 define subst-metadata
 	@echo -n "Generating files: ${SUBST_FILES}... ";
@@ -53,6 +54,12 @@ mesa-git:
 	flatpak-builder --force-clean --require-changes --repo=${REPO} --arch=${ARCH} \
 		--subject="build of org.freedesktop.Platform.GL.mesa-git, `date`" \
 		${EXPORT_ARGS} mesa org.freedesktop.Platform.GL.mesa-git.json
+
+vaapi-intel:
+	$(call subst-metadata)
+	flatpak-builder --force-clean --require-changes --repo=${REPO} --arch=${ARCH} \
+		--subject="build of org.freedesktop.Platform.VAAPI.Intel, `date`" \
+		${EXPORT_ARGS} vaapi-intel org.freedesktop.Platform.VAAPI.Intel.json
 
 runtimes: ${REPO} $(patsubst %,%.in,$(SUBST_FILES))
 	$(call subst-metadata)

--- a/org.freedesktop.Platform.VAAPI.Intel.json.in
+++ b/org.freedesktop.Platform.VAAPI.Intel.json.in
@@ -1,0 +1,22 @@
+{
+    "id": "org.freedesktop.Platform.VAAPI.Intel",
+    "branch": "@@SDK_BRANCH@@",
+    "runtime": "org.freedesktop.Platform",
+    "build-extension": true,
+    "sdk": "org.freedesktop.Sdk",
+    "runtime-version": "@@SDK_BRANCH@@",
+    "separate-locales": false,
+    "modules": [
+        {
+            "name": "intel-vaapi-driver",
+            "config-opts": [ "--disable-static", "LIBVA_DRIVERS_PATH=/usr/lib/dri/intel-vaapi-driver" ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://www.freedesktop.org/software/vaapi/releases/libva-intel-driver/intel-vaapi-driver-1.8.2.tar.bz2",
+                    "sha256": "866cdf9974911e58b0d3a2cade29dbe7b5b68836e142cf092b99db68e366b702"
+                }
+            ]
+        }
+    ]
+}

--- a/org.freedesktop.Sdk.json.in
+++ b/org.freedesktop.Sdk.json.in
@@ -33,6 +33,8 @@
         "--extension=org.freedesktop.Sdk.Extension=subdirectories",
         "--extension=org.freedesktop.Sdk.Extension=directory=lib/sdk",
         "--extension=org.freedesktop.Sdk.Extension=no-autodownload=true",
+        "--extension=org.freedesktop.Platform.VAAPI.Intel=directory=lib/dri/intel-vaapi-driver",
+        "--extension=org.freedesktop.Platform.VAAPI.Intel=autodelete=false",
         "--env=GI_TYPELIB_PATH=/app/lib/girepository-1.0",
         "--env=GST_PLUGIN_SYSTEM_PATH=/app/lib/gstreamer-1.0:/usr/lib/extensions/gstreamer-1.0:/usr/lib/gstreamer-1.0",
         "--env=XDG_DATA_DIRS=/app/share:/usr/share:/usr/share/runtime/share",
@@ -2387,6 +2389,20 @@
                     "commands": [
                         "mkdir -p /usr/lib/extra-links",
                         "ln -s /app/lib/ld-linux-armhf.so.3 /usr/lib/extra-links/ld-linux-armhf.so.3"
+                    ]
+                }
+            ],
+            "buildsystem": "simple",
+            "build-commands": []
+        },
+        {
+            "name": "intel-vaapi-driver-stub",
+            "sources": [
+                {
+                    "type": "shell",
+                    "commands": [
+                        "mkdir -p /usr/lib/dri/intel-vaapi-driver",
+                        "ln -s /usr/lib/dri/intel-vaapi-driver/i965_drv_video.so /usr/lib/dri/i965_drv_video.so"
                     ]
                 }
             ],


### PR DESCRIPTION
Fix flatpak/flatpak#4

I bumped to 1.7 because runtimes based on this one would need a rebuild by adding the correct --extension parameters, which looks like an API breakage to me but not sure.