### PR TITLE
Enable rawmidi and instr in Alsa lib. Required by XCOM2 and Dirt Rally.

### DIFF
--- a/org.freedesktop.Sdk.json.in
+++ b/org.freedesktop.Sdk.json.in
@@ -1412,7 +1412,6 @@
         {
             "name": "alsa-lib",
             "config-opts": [ "--disable-aload", "--disable-alisp", "--disable-old-symbols",
-                             "--disable-rawmidi", "--disable-instr",
                              "--with-pcm-plugins=hw ioplug extplug"],
             "sources": [
                 {


### PR DESCRIPTION
Both games require some missing symbols in libasound. Should help for flathub/com.valvesoftware.Steam#9