### PR TITLE
Add /app/share/icons to libXcursor lookup paths

### DIFF
--- a/org.freedesktop.Sdk.json.in
+++ b/org.freedesktop.Sdk.json.in
@@ -885,7 +885,7 @@
         },
         {
             "name": "libXcursor",
-            "config-opts": [ "--disable-static" ],
+            "config-opts": [ "--disable-static", "--with-cursorpath=~/.icons:${datadir}/icons:${datadir}/pixmaps:/app/share/icons" ],
             "sources": [
                  {
                      "type": "archive",


### PR DESCRIPTION
Cursor themes may be installed in /app/share/icons, but since
libXcursor is part of the runtime, by default it will only look in
/usr/share/icons. Add the /app path as an additional lookup.