### PR TITLE
Relative lib path

### DIFF
--- a/alsa-lib-plugin-path.patch
+++ b/alsa-lib-plugin-path.patch
@@ -1,0 +1,41 @@
+diff -ur alsa-lib-1.1.4.1.old/src/dlmisc.c alsa-lib-1.1.4.1/src/dlmisc.c
+--- alsa-lib-1.1.4.1.old/src/dlmisc.c	2017-06-01 08:27:36.000000000 +0200
++++ alsa-lib-1.1.4.1/src/dlmisc.c	2017-10-15 21:55:52.444803512 +0200
+@@ -32,6 +32,7 @@
+ #ifdef HAVE_LIBPTHREAD
+ #include <pthread.h>
+ #endif
++#include <linux/limits.h>
+ 
+ #ifndef DOC_HIDDEN
+ #ifndef PIC
+@@ -76,8 +77,27 @@
+ 	char *filename;
+ 
+ 	if (name && name[0] != '/') {
+-		filename = malloc(sizeof(ALSA_PLUGIN_DIR) + 1 + strlen(name) + 1);
+-		strcpy(filename, ALSA_PLUGIN_DIR);
++                struct link_map* links;
++                Dl_info info;
++                char origin[PATH_MAX];
++
++                if (dladdr1(&snd_dlopen, &info,
++                            (void**)&links, RTLD_DL_LINKMAP)
++                    == 0) {
++                        links = NULL;
++                }
++
++
++                if ((links != NULL)
++                    && (dlinfo(links, RTLD_DI_ORIGIN, origin) == 0)) {
++                      filename = malloc(strlen(origin) + 1 + 8 /*strlen("alsa-lib")*/ +  1 + strlen(name) + 1);
++                      strcpy(filename, origin);
++                      strcpy(filename, "/alsa-lib");
++                } else {
++                      filename = malloc(sizeof(ALSA_PLUGIN_DIR) + 1 + strlen(name) + 1);
++                      strcpy(filename, ALSA_PLUGIN_DIR);
++                }
++
+ 		strcat(filename, "/");
+ 		strcat(filename, name);
+ 		handle = dlopen(filename, mode);

--- a/alsa-lib-plugin-path.patch
+++ b/alsa-lib-plugin-path.patch
@@ -1,3 +1,34 @@
+diff -ur alsa-lib-1.1.4.1.old/modules/mixer/simple/sbasedl.c alsa-lib-1.1.4.1/modules/mixer/simple/sbasedl.c
+--- alsa-lib-1.1.4.1.old/modules/mixer/simple/sbasedl.c	2017-06-01 08:27:36.000000000 +0200
++++ alsa-lib-1.1.4.1/modules/mixer/simple/sbasedl.c	2017-10-16 21:42:22.819834082 +0200
+@@ -33,7 +33,7 @@
+ #include "mixer_abst.h"
+ #include "sbase.h"
+ 
+-#define SO_PATH ALSA_PLUGIN_DIR "/smixer"
++#define SO_PATH "smixer"
+ 
+ int mixer_simple_basic_dlopen(snd_mixer_class_t *class,
+ 			      bclass_base_ops_t **ops)
+diff -ur alsa-lib-1.1.4.1.old/src/control/control.c alsa-lib-1.1.4.1/src/control/control.c
+--- alsa-lib-1.1.4.1.old/src/control/control.c	2017-06-01 08:27:36.000000000 +0200
++++ alsa-lib-1.1.4.1/src/control/control.c	2017-10-16 21:42:12.480013374 +0200
+@@ -1331,13 +1331,13 @@
+ 			build_in++;
+ 		}
+ 		if (*build_in == NULL) {
+-			buf1 = malloc(strlen(str) + sizeof(ALSA_PLUGIN_DIR) + 32);
++			buf1 = malloc(strlen(str) + 32);
+ 			if (buf1 == NULL) {
+ 				err = -ENOMEM;
+ 				goto _err;
+ 			}
+ 			lib = buf1;
+-			sprintf(buf1, "%s/libasound_module_ctl_%s.so", ALSA_PLUGIN_DIR, str);
++			sprintf(buf1, "libasound_module_ctl_%s.so", str);
+ 		}
+ 	}
+ #ifndef PIC
 diff -ur alsa-lib-1.1.4.1.old/src/dlmisc.c alsa-lib-1.1.4.1/src/dlmisc.c
 --- alsa-lib-1.1.4.1.old/src/dlmisc.c	2017-06-01 08:27:36.000000000 +0200
 +++ alsa-lib-1.1.4.1/src/dlmisc.c	2017-10-17 09:47:23.659893291 +0200
@@ -39,3 +70,46 @@ diff -ur alsa-lib-1.1.4.1.old/src/dlmisc.c alsa-lib-1.1.4.1/src/dlmisc.c
  		strcat(filename, "/");
  		strcat(filename, name);
  		handle = dlopen(filename, mode);
+diff -ur alsa-lib-1.1.4.1.old/src/mixer/simple_abst.c alsa-lib-1.1.4.1/src/mixer/simple_abst.c
+--- alsa-lib-1.1.4.1.old/src/mixer/simple_abst.c	2017-06-01 08:27:36.000000000 +0200
++++ alsa-lib-1.1.4.1/src/mixer/simple_abst.c	2017-10-16 21:42:20.429875375 +0200
+@@ -41,7 +41,7 @@
+ 
+ #ifndef DOC_HIDDEN
+ 
+-#define SO_PATH ALSA_PLUGIN_DIR "/smixer"
++#define SO_PATH "smixer"
+ 
+ typedef struct _class_priv {
+ 	char *device;
+diff -ur alsa-lib-1.1.4.1.old/src/pcm/pcm.c alsa-lib-1.1.4.1/src/pcm/pcm.c
+--- alsa-lib-1.1.4.1.old/src/pcm/pcm.c	2017-06-01 08:27:36.000000000 +0200
++++ alsa-lib-1.1.4.1/src/pcm/pcm.c	2017-10-16 21:41:24.710724708 +0200
+@@ -2432,13 +2432,13 @@
+ 			build_in++;
+ 		}
+ 		if (*build_in == NULL) {
+-			buf1 = malloc(strlen(str) + sizeof(ALSA_PLUGIN_DIR) + 32);
++			buf1 = malloc(strlen(str) + 32);
+ 			if (buf1 == NULL) {
+ 				err = -ENOMEM;
+ 				goto _err;
+ 			}
+ 			lib = buf1;
+-			sprintf(buf1, "%s/libasound_module_pcm_%s.so", ALSA_PLUGIN_DIR, str);
++			sprintf(buf1, "libasound_module_pcm_%s.so", str);
+ 		}
+ 	}
+ #ifndef PIC
+diff -ur alsa-lib-1.1.4.1.old/src/pcm/pcm_rate.c alsa-lib-1.1.4.1/src/pcm/pcm_rate.c
+--- alsa-lib-1.1.4.1.old/src/pcm/pcm_rate.c	2017-06-01 08:27:36.000000000 +0200
++++ alsa-lib-1.1.4.1/src/pcm/pcm_rate.c	2017-10-16 21:42:35.329619399 +0200
+@@ -1269,7 +1269,7 @@
+ 	snprintf(open_conf_name, sizeof(open_conf_name), "_snd_pcm_rate_%s_open_conf", type);
+ 	if (!is_builtin_plugin(type)) {
+ 		snprintf(lib_name, sizeof(lib_name),
+-				 "%s/libasound_module_rate_%s.so", ALSA_PLUGIN_DIR, type);
++				 "libasound_module_rate_%s.so", type);
+ 		lib = lib_name;
+ 	}
+ 

--- a/alsa-lib-plugin-path.patch
+++ b/alsa-lib-plugin-path.patch
@@ -1,6 +1,6 @@
 diff -ur alsa-lib-1.1.4.1.old/src/dlmisc.c alsa-lib-1.1.4.1/src/dlmisc.c
 --- alsa-lib-1.1.4.1.old/src/dlmisc.c	2017-06-01 08:27:36.000000000 +0200
-+++ alsa-lib-1.1.4.1/src/dlmisc.c	2017-10-15 21:55:52.444803512 +0200
++++ alsa-lib-1.1.4.1/src/dlmisc.c	2017-10-17 09:47:23.659893291 +0200
 @@ -32,6 +32,7 @@
  #ifdef HAVE_LIBPTHREAD
  #include <pthread.h>
@@ -30,7 +30,7 @@ diff -ur alsa-lib-1.1.4.1.old/src/dlmisc.c alsa-lib-1.1.4.1/src/dlmisc.c
 +                    && (dlinfo(links, RTLD_DI_ORIGIN, origin) == 0)) {
 +                      filename = malloc(strlen(origin) + 1 + 8 /*strlen("alsa-lib")*/ +  1 + strlen(name) + 1);
 +                      strcpy(filename, origin);
-+                      strcpy(filename, "/alsa-lib");
++                      strcat(filename, "/alsa-lib");
 +                } else {
 +                      filename = malloc(sizeof(ALSA_PLUGIN_DIR) + 1 + strlen(name) + 1);
 +                      strcpy(filename, ALSA_PLUGIN_DIR);

--- a/mesa-dri-path.patch
+++ b/mesa-dri-path.patch
@@ -1,0 +1,162 @@
+diff -ur mesa-17.0.7.old/src/egl/drivers/dri2/egl_dri2.c mesa-17.0.7/src/egl/drivers/dri2/egl_dri2.c
+--- mesa-17.0.7.old/src/egl/drivers/dri2/egl_dri2.c	2017-06-01 12:37:10.000000000 +0200
++++ mesa-17.0.7/src/egl/drivers/dri2/egl_dri2.c	2017-10-15 20:09:45.174556143 +0200
+@@ -454,12 +454,32 @@
+    return ret;
+ }
+ 
++static
++int get_origin_path(char* origin)
++{
++    struct link_map* links;
++    Dl_info info;
++
++    if (dladdr1(&get_origin_path, &info, (void**)&links, RTLD_DL_LINKMAP)
++        == 0) {
++        return 0;
++    }
++
++    if (dlinfo(links, RTLD_DI_ORIGIN, origin)
++        != 0) {
++        return 0;
++    }
++
++    return 1;
++}
++
+ static const __DRIextension **
+ dri2_open_driver(_EGLDisplay *disp)
+ {
+    struct dri2_egl_display *dri2_dpy = dri2_egl_display(disp);
+    const __DRIextension **extensions = NULL;
+    char path[PATH_MAX], *search_paths, *p, *next, *end;
++   char origin_path[PATH_MAX];
+    char *get_extensions_name;
+    const __DRIextension **(*get_extensions)(void);
+ 
+@@ -468,6 +488,14 @@
+       /* don't allow setuid apps to use LIBGL_DRIVERS_PATH */
+       search_paths = getenv("LIBGL_DRIVERS_PATH");
+    }
++   if (search_paths == NULL) {
++       if (get_origin_path(origin_path)) {
++           if (strlen(origin_path) < (PATH_MAX - 4)) {
++               strcat(origin_path, "/dri");
++               search_paths = origin_path;
++           }
++       }
++   }
+    if (search_paths == NULL)
+       search_paths = DEFAULT_DRIVER_DIR;
+ 
+diff -ur mesa-17.0.7.old/src/gbm/backends/dri/gbm_dri.c mesa-17.0.7/src/gbm/backends/dri/gbm_dri.c
+--- mesa-17.0.7.old/src/gbm/backends/dri/gbm_dri.c	2017-06-01 12:37:10.000000000 +0200
++++ mesa-17.0.7/src/gbm/backends/dri/gbm_dri.c	2017-10-15 20:08:44.075238466 +0200
+@@ -290,11 +290,31 @@
+    return ret;
+ }
+ 
++static
++int get_origin_path(char* origin)
++{
++    struct link_map* links;
++    Dl_info info;
++
++    if (dladdr1(&get_origin_path, &info, (void**)&links, RTLD_DL_LINKMAP)
++        == 0) {
++        return 0;
++    }
++
++    if (dlinfo(links, RTLD_DI_ORIGIN, origin)
++        != 0) {
++        return 0;
++    }
++
++    return 1;
++}
++
+ static const __DRIextension **
+ dri_open_driver(struct gbm_dri_device *dri)
+ {
+    const __DRIextension **extensions = NULL;
+    char path[PATH_MAX], *search_paths, *p, *next, *end;
++   char origin_path[PATH_MAX];
+    char *get_extensions_name;
+ 
+    search_paths = NULL;
+@@ -312,6 +332,14 @@
+          search_paths = getenv("LIBGL_DRIVERS_PATH");
+       }
+    }
++   if (search_paths == NULL) {
++       if (get_origin_path(origin_path)) {
++           if (strlen(origin_path) < (PATH_MAX - 4)) {
++               strcat(origin_path, "/dri");
++               search_paths = origin_path;
++           }
++       }
++   }
+    if (search_paths == NULL)
+       search_paths = DEFAULT_DRIVER_DIR;
+ 
+diff -ur mesa-17.0.7.old/src/glx/dri_common.c mesa-17.0.7/src/glx/dri_common.c
+--- mesa-17.0.7.old/src/glx/dri_common.c	2017-06-01 12:37:10.000000000 +0200
++++ mesa-17.0.7/src/glx/dri_common.c	2017-10-15 20:08:44.075238466 +0200
+@@ -38,6 +38,7 @@
+ #include <unistd.h>
+ #include <dlfcn.h>
+ #include <stdarg.h>
++#include <linux/limits.h>
+ #include "glxclient.h"
+ #include "dri_common.h"
+ #include "loader.h"
+@@ -82,6 +83,25 @@
+ #define DEFAULT_DRIVER_DIR "/usr/local/lib/dri"
+ #endif
+ 
++static
++int get_origin_path(char* origin)
++{
++    struct link_map* links;
++    Dl_info info;
++
++    if (dladdr1(&get_origin_path, &info, (void**)&links, RTLD_DL_LINKMAP)
++        == 0) {
++        return 0;
++    }
++
++    if (dlinfo(links, RTLD_DI_ORIGIN, origin)
++        != 0) {
++        return 0;
++    }
++
++    return 1;
++}
++
+ /**
+  * Try to \c dlopen the named driver.
+  *
+@@ -99,6 +119,7 @@
+ {
+    void *glhandle, *handle;
+    const char *libPaths, *p, *next;
++   char origin_path[PATH_MAX];
+    char realDriverName[200];
+    int len;
+ 
+@@ -112,6 +133,15 @@
+       if (!libPaths)
+          libPaths = getenv("LIBGL_DRIVERS_DIR");        /* deprecated */
+    }
++   if (libPaths == NULL) {
++       if (get_origin_path(origin_path)) {
++           if (strlen(origin_path) < (PATH_MAX - 4)) {
++               strcat(origin_path, "/dri");
++               libPaths = origin_path;
++           }
++       }
++   }
++
+    if (libPaths == NULL)
+       libPaths = DEFAULT_DRIVER_DIR;
+ 

--- a/org.freedesktop.Sdk.json.in
+++ b/org.freedesktop.Sdk.json.in
@@ -1438,6 +1438,9 @@
                      "url": "http://www.freedesktop.org/software/pulseaudio/releases/pulseaudio-10.0.tar.xz",
                      "sha256": "a3186824de9f0d2095ded5d0d0db0405dc73133983c2fbb37291547e37462f57"
                  }
+            ],
+            "post-install": [
+                "chrpath -r '$ORIGIN/pulseaudio' /usr/lib/libpulse*.so"
             ]
         },
         {

--- a/org.freedesktop.Sdk.json.in
+++ b/org.freedesktop.Sdk.json.in
@@ -1472,7 +1472,11 @@
             "name": "alsa-plugins",
             "config-opts": [ "--disable-jack", "--enable-pulseaudio", "--disable-samplerate",
                              "--disable-avcodec", "--with-speex=no"],
-            "post-install": [ "mv /usr/share/alsa/alsa.conf.d/99-pulseaudio-default.conf.example /usr/share/alsa/alsa.conf.d/99-pulseaudio-default.conf" ],
+            "post-install": [
+                "mv /usr/share/alsa/alsa.conf.d/99-pulseaudio-default.conf.example /usr/share/alsa/alsa.conf.d/99-pulseaudio-default.conf",
+                "ln -s ../pulseaudio /usr/lib/alsa-lib/pulseaudio",
+                "chrpath -r '$ORIGIN/pulseaudio' /usr/lib/alsa-lib/libasound_module_pcm_pulse.so"
+            ],
             "sources": [
                 {
                     "type": "archive",
@@ -1484,10 +1488,6 @@
                     "dest-filename": "autogen.sh",
                     "commands": [ "autoreconf -i" ]
                 }
-            ],
-            "post-install": [
-                "ln -s ../pulseaudio /usr/lib/alsa-lib/pulseaudio",
-                "chrpath -r '$ORIGIN/pulseaudio' /usr/lib/alsa-lib/libasound_module_pcm_pulse.so"
             ]
         },
         {

--- a/org.freedesktop.Sdk.json.in
+++ b/org.freedesktop.Sdk.json.in
@@ -1484,6 +1484,10 @@
                     "dest-filename": "autogen.sh",
                     "commands": [ "autoreconf -i" ]
                 }
+            ],
+            "post-install": [
+                "ln -s /usr/lib/pulseaudio /usr/lib/alsa-lib/pulseaudio",
+                "chrpath -r '$ORIGIN/pulseaudio' /usr/lib/alsa-lib/libasound_module_pcm_pulse.so"
             ]
         },
         {

--- a/org.freedesktop.Sdk.json.in
+++ b/org.freedesktop.Sdk.json.in
@@ -1486,7 +1486,7 @@
                 }
             ],
             "post-install": [
-                "ln -s /usr/lib/pulseaudio /usr/lib/alsa-lib/pulseaudio",
+                "ln -s ../pulseaudio /usr/lib/alsa-lib/pulseaudio",
                 "chrpath -r '$ORIGIN/pulseaudio' /usr/lib/alsa-lib/libasound_module_pcm_pulse.so"
             ]
         },

--- a/org.freedesktop.Sdk.json.in
+++ b/org.freedesktop.Sdk.json.in
@@ -1461,6 +1461,10 @@
                     "type": "script",
                     "dest-filename": "autogen.sh",
                     "commands": [ "autoreconf -i" ]
+                },
+                {
+                    "type": "patch",
+                    "path": "alsa-lib-plugin-path.patch"
                 }
             ]
         },

--- a/org.freedesktop.Sdk.json.in
+++ b/org.freedesktop.Sdk.json.in
@@ -1361,6 +1361,10 @@
                 {
                     "type": "patch",
                     "path": "mesa-Fix-linkage-against-shared-glapi.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "mesa-dri-path.patch"
                 }
             ]
         },


### PR DESCRIPTION
This fixes few fixed, absolute library paths. This is a problem with Compat32 because it is mounted in a different place than expected.

For Steam, it removes the need to define variable LIBGL_DRIVERS_PATH.