### PR TITLE
Add Nvidia OpenCL ICD loader

### DIFF
--- a/nvidia-apply-extra.c
+++ b/nvidia-apply-extra.c
@@ -368,6 +368,7 @@ main (int argc, char *argv[])
       symlink ("libEGL_nvidia.so." NVIDIA_VERSION, "libEGL_nvidia.so.0");
       symlink ("libGLESv2_nvidia.so." NVIDIA_VERSION, "libGLESv2_nvidia.so.2");
       symlink ("libGLX_nvidia.so." NVIDIA_VERSION, "libGLX_nvidia.so.0");
+      symlink ("libnvidia-ptxjitcompiler.so." NVIDIA_VERSION, "libnvidia-ptxjitcompiler.so.1");
     }
   else
     {

--- a/nvidia-apply-extra.c
+++ b/nvidia-apply-extra.c
@@ -318,6 +318,20 @@ replace_string_in_file (const char *path,
   fclose (f);
 }
 
+static void create_file_with_content(const char *path,
+                                     const char *string)
+{
+  FILE *f;
+
+  if ((f = fopen (path, "w+")) == NULL)
+    die_with_error ("creating file %s", path);
+
+  if (fprintf(f, "%s\n", string) != strlen(string) + 1)
+    die ("failed to write to file %s", path);
+
+  fclose (f);
+}
+
 
 int
 main (int argc, char *argv[])
@@ -370,6 +384,8 @@ main (int argc, char *argv[])
   symlink ("libnvidia-encode.so." NVIDIA_VERSION, "libnvidia-encode.so.1");
   symlink ("libnvcuvid.so." NVIDIA_VERSION, "libnvcuvid.so.1");
   symlink ("libnvidia-opencl.so." NVIDIA_VERSION, "libnvidia-opencl.so");
+
+  create_file_with_content ("OpenCL/vendors/nvidia.icd", "libnvidia-opencl.so");
 
   if (nvidia_major_version > 340)
     replace_string_in_file ("vulkan/icd.d/nvidia_icd.json",

--- a/nvidia-apply-extra.c
+++ b/nvidia-apply-extra.c
@@ -369,6 +369,7 @@ main (int argc, char *argv[])
   symlink ("libcuda.so." NVIDIA_VERSION, "libcuda.so.1");
   symlink ("libnvidia-encode.so." NVIDIA_VERSION, "libnvidia-encode.so.1");
   symlink ("libnvcuvid.so." NVIDIA_VERSION, "libnvcuvid.so.1");
+  symlink ("libnvidia-opencl.so." NVIDIA_VERSION, "libnvidia-opencl.so");
 
   if (nvidia_major_version > 340)
     replace_string_in_file ("vulkan/icd.d/nvidia_icd.json",


### PR DESCRIPTION
This provides:
- missing "libnvidia-opencl.so" and "libnvidia-ptxjitcompiler.so.1" symlinks
- "OpenCL/vendors/nvidia.icd" ICD loader filer containing "libnvidia-opencl.so" text