### PR TITLE
Enable gallium nine in mesa for x86_64+i386

### DIFF
--- a/org.freedesktop.Platform.GL.mesa-stable.json.in
+++ b/org.freedesktop.Platform.GL.mesa-stable.json.in
@@ -94,6 +94,7 @@
                             "--build=i586-unknown-linux-gnu",
 			    "--with-gallium-drivers=svga,swrast,nouveau,r600,r300,radeonsi",
 			    "--with-dri-drivers=swrast,nouveau,radeon,r200,i915,i965",
+			    "--enable-nine",
 			    "--with-vulkan-drivers=intel,radeon"
 			]
 		    },
@@ -101,6 +102,7 @@
 			"config-opts" : [
 			    "--with-gallium-drivers=svga,swrast,nouveau,r600,r300,radeonsi",
 			    "--with-dri-drivers=swrast,nouveau,radeon,r200,i915,i965",
+			    "--enable-nine",
 			    "--with-vulkan-drivers=intel,radeon"
 			]
 		    },


### PR DESCRIPTION
This enables mesa to be compiled with gallium nine support on x86_64 and i386. This can be used in conjunction with wine-gallium-nine (wine with gallium nine patchset) and will allow wine-gallium-nine to be used in a flatpak. This can increase performance for wine users with mesa drivers.