### PR TITLE
Preserve gfortran lib symbolic links on install

### DIFF
--- a/org.freedesktop.Sdk.Extension.gfortran62.json.in
+++ b/org.freedesktop.Sdk.Extension.gfortran62.json.in
@@ -75,7 +75,7 @@
                     "type": "script",
                     "commands": [
                         "mkdir -p /app/lib",
-                        "cp /usr/lib/sdk/gfortran-62/lib/libquadmath.so* /usr/lib/sdk/gfortran-62/lib/libgfortran.so.3* /app/lib/"
+                        "cp -P /usr/lib/sdk/gfortran-62/lib/libquadmath.so* /usr/lib/sdk/gfortran-62/lib/libgfortran.so* /app/lib/"
                     ],
                     "dest-filename": "install.sh"
                 },


### PR DESCRIPTION
Also copy the libgfortran.so symbolic link needed when building.

Closes #89 