### PR TITLE
Remove useless Perl script

### DIFF
--- a/org.freedesktop.Sdk.json.in
+++ b/org.freedesktop.Sdk.json.in
@@ -2469,7 +2469,7 @@
         },
         {
             "name": "zenity",
-            "cleanup": [ "/share/help" ],
+            "cleanup": [ "/bin/gdialog", "/share/help" ],
             "config-opts": ["--disable-webkitgtk" ],
             "sources": [
                 {


### PR DESCRIPTION
This script is useless because there's no Perl in the run-time. For
what it's worth, the zenity package in Fedora also removes the gdialog
script, and the world hasn't fallen apart.