### PR TITLE
Update appstream-glib to 0.7.8

### DIFF
--- a/org.freedesktop.Sdk.json.in
+++ b/org.freedesktop.Sdk.json.in
@@ -2326,9 +2326,9 @@
                              "-Dstemmer=false" ],
             "sources": [
                 {
-                     "type": "archive",
-                    "url": "https://people.freedesktop.org/~hughsient/appstream-glib/releases/appstream-glib-0.7.7.tar.xz",
-                    "sha256": "bc979456c4ff6bc7434115ef20718d9f7c79cae5110f15d6fe5fae53a5fe800a"
+                    "type": "archive",
+                    "url": "https://people.freedesktop.org/~hughsient/appstream-glib/releases/appstream-glib-0.7.8.tar.xz",
+                    "sha256": "eb0e2cfd5a6070615efea4c87b1fc539f4566085aa5f5b41945f679d9d61dd4c"
                 }
             ]
         },


### PR DESCRIPTION
New Features:
 - Add as_store_get_app_by_launchable() (Richard Hughes)
 - Add as_utils_unique_id_match() (Richard Hughes)
 - Add as_version_string() for fwupd (Richard Hughes)
 - Add support for component agreements (Richard Hughes)

Bugfixes:
 - Correctly compare version numbers like '1.2.3' and '1.2.3a' (Richard Hughes)
 - Don't include the path component in the name when parsing the package filename (Richard Hughes)
 - If the launchable is specified don't guess it when composing (Richard Hughes)
 - Never add more than one component to the AppStream store when composing (Richard Hughes)
 - Veto apps that have empty OnlyShowIn= (Kalev Lember)