### PR TITLE
add wayland patch to make cursor loading respect XDG dirs

### DIFF
--- a/org.freedesktop.Sdk.json.in
+++ b/org.freedesktop.Sdk.json.in
@@ -1303,11 +1303,15 @@
             "config-opts": ["--disable-static", "--disable-documentation"],
             "cleanup-platform": [ "/bin/wayland-scanner" ],
             "sources": [
-                 {
-                     "type": "archive",
-                     "url": "https://wayland.freedesktop.org/releases/wayland-1.15.0.tar.xz",
-                     "sha256": "eb3fbebb8559d56a80ad3753ec3db800f587329067962dbf65e14488b4b7aeb0"
-                 }
+                {
+                    "type": "archive",
+                    "url": "https://wayland.freedesktop.org/releases/wayland-1.15.0.tar.xz",
+                    "sha256": "eb3fbebb8559d56a80ad3753ec3db800f587329067962dbf65e14488b4b7aeb0"
+                },
+                {
+                    "type": "patch",
+                    "path": "wayland-cursor-xdg-dirs.patch"
+                }
             ]
         },
         {

--- a/wayland-cursor-xdg-dirs.patch
+++ b/wayland-cursor-xdg-dirs.patch
@@ -1,0 +1,208 @@
+From abea67d38acecdcf6e70f2f4bce090b158dee161 Mon Sep 17 00:00:00 2001
+From: Robert McQueen <rob@endlessm.com>
+Date: Wed, 16 May 2018 14:43:34 +0100
+Subject: [PATCH] cursor: check XDG_DATA_HOME and XDG_DATA_DIRS for cursor
+ themes
+
+Use the XDG-defined user and system dirs to look for icons/ directories
+before falling back to hardcoded default/legacy XCURSOR_PATH values. Fixes
+the availability of themed cursors in sandboxed and other environments
+that rely on XDG_DATA_DIRS being set and respected.
+---
+ cursor/xcursor.c | 150 +++++++++++++++++++++++++++++++++++++++++++++----------
+ 1 file changed, 125 insertions(+), 25 deletions(-)
+
+diff --git a/cursor/xcursor.c b/cursor/xcursor.c
+index 689c702..8ed15fc 100644
+--- a/cursor/xcursor.c
++++ b/cursor/xcursor.c
+@@ -24,6 +24,8 @@
+  */
+ 
+ #include "xcursor.h"
++
++#define _GNU_SOURCE
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
+@@ -608,6 +610,14 @@ XcursorFileLoadImages (FILE *file, int size)
+     return XcursorXcFileLoadImages (&f, size);
+ }
+ 
++#ifndef USER_DATA_DIR
++#define USER_DATA_DIR ".local/share/"
++#endif
++
++#ifndef ICON_SUBDIR
++#define ICON_SUBDIR "icons/"
++#endif
++
+ /*
+  * From libXcursor/src/library.c
+  */
+@@ -617,23 +627,9 @@ XcursorFileLoadImages (FILE *file, int size)
+ #endif
+ 
+ #ifndef XCURSORPATH
+-#define XCURSORPATH "~/.icons:/usr/share/icons:/usr/share/pixmaps:~/.cursors:/usr/share/cursors/xorg-x11:"ICONDIR
++#define XCURSORPATH "~/.icons/:/usr/share/pixmaps/:~/.cursors/:/usr/share/cursors/xorg-x11/:"ICONDIR
+ #endif
+ 
+-static const char *
+-XcursorLibraryPath (void)
+-{
+-    static const char	*path;
+-
+-    if (!path)
+-    {
+-	path = getenv ("XCURSOR_PATH");
+-	if (!path)
+-	    path = XCURSORPATH;
+-    }
+-    return path;
+-}
+-
+ static  void
+ _XcursorAddPathElt (char *path, const char *elt, int len)
+ {
+@@ -657,6 +653,120 @@ _XcursorAddPathElt (char *path, const char *elt, int len)
+     path[pathlen + len] = '\0';
+ }
+ 
++static const char *
++_XcursorNextPath (const char *path)
++{
++    char    *colon = strchr (path, ':');
++
++    if (!colon)
++	return NULL;
++    return colon + 1;
++}
++
++static const char *
++_XcursorDataDirs (void)
++{
++    static char	        *data_dirs = NULL;
++    const char          *xdg_data_home = NULL;
++    const char          *xdg_data_dirs = NULL;
++    char                *user_data_dir = NULL;
++    int                 user_data_dir_len;
++
++    if (data_dirs)
++        return data_dirs;
++
++    xdg_data_home = getenv ("XDG_DATA_HOME");
++    if (!xdg_data_home || !xdg_data_home[0])
++        xdg_data_home = "~/";
++
++    xdg_data_dirs = getenv ("XDG_DATA_DIRS");
++    if (!xdg_data_dirs || !xdg_data_dirs[0])
++        xdg_data_dirs = "/usr/local/share/:/usr/share/";
++
++    /* home dir + / + .local/share/ + NULL */
++    user_data_dir_len = strlen (xdg_data_home) + 1 + strlen (USER_DATA_DIR) + 1;
++    user_data_dir = malloc (user_data_dir_len);
++    if (!user_data_dir)
++        return NULL;
++
++    strcpy (user_data_dir, xdg_data_home);
++    _XcursorAddPathElt (user_data_dir, USER_DATA_DIR, strlen (USER_DATA_DIR));
++
++    data_dirs = NULL;
++    asprintf (&data_dirs, "%s:%s", user_data_dir, xdg_data_dirs);
++    free (user_data_dir);
++
++    return data_dirs;
++}
++
++static const char *
++XcursorLibraryPath (void)
++{
++    static char *path = NULL;
++    const char *dir;
++    const char *colon;
++    char *tmp;
++    char *oldpath;
++    int dirlen;
++    int len;
++
++    if (path)
++        return path;
++
++    path = getenv ("XCURSOR_PATH");
++    if (path)
++        return path;
++
++    for (dir = _XcursorDataDirs ();
++	 dir;
++	 dir = _XcursorNextPath (dir))
++    {
++        colon = strchr (dir, ':');
++        if (!colon)
++	    colon = dir + strlen (dir);
++
++        dirlen = colon - dir;
++
++        len = dirlen + 1 + strlen (ICON_SUBDIR) + 1;
++        tmp = malloc (len);
++        if (!tmp)
++        {
++            free (path);
++            path = NULL;
++            return NULL;
++        }
++
++        strncpy (tmp, dir, dirlen);
++        tmp[dirlen] = '\0';
++        _XcursorAddPathElt (tmp, ICON_SUBDIR, strlen (ICON_SUBDIR));
++
++        if (!path)
++        {
++            path = tmp;
++            continue;
++        }
++
++        oldpath = path;
++        path = NULL;
++        asprintf (&path, "%s:%s", oldpath, tmp);
++        if (!path)
++        {
++            free (tmp);
++            return NULL;
++        }
++
++        free (tmp);
++        free (oldpath);
++    }
++
++    oldpath = path;
++    path = NULL;
++    asprintf (&path, "%s:%s", oldpath, XCURSORPATH);
++    free (oldpath);
++
++    return path;
++}
++
+ static char *
+ _XcursorBuildThemeDir (const char *dir, const char *theme)
+ {
+@@ -732,16 +842,6 @@ _XcursorBuildFullname (const char *dir, const char *subdir, const char *file)
+     return full;
+ }
+ 
+-static const char *
+-_XcursorNextPath (const char *path)
+-{
+-    char    *colon = strchr (path, ':');
+-
+-    if (!colon)
+-	return NULL;
+-    return colon + 1;
+-}
+-
+ #define XcursorWhite(c)	((c) == ' ' || (c) == '\t' || (c) == '\n')
+ #define XcursorSep(c) ((c) == ';' || (c) == ',')
+ 
+-- 
+2.11.0
+


### PR DESCRIPTION
There is a subtle cursor theming bug caused in apps that depend on
freedesktop.org rather than gnome.org runtimes because the Adwaita
theme (including the commonly used cursors) appears in the extension
path /usr/share/runtime/... which is not normally checked by the
code lifted from libXcursor. Check the XDG user and system data
dirs before the legaxy X cursor paths.

https://github.com/flathub/org.libreoffice.LibreOffice/issues/32