### PR TITLE
Add org.freedesktop.Sdk.Tools extension point

### DIFF
--- a/org.freedesktop.Sdk.json.in
+++ b/org.freedesktop.Sdk.json.in
@@ -50,6 +50,13 @@
             "directory": "lib/sdk",
             "no-autodownload": true
         },
+        "org.freedesktop.Sdk.Tools": {
+            "directory": "bin/sdk",
+            "add-ld-path": "lib",
+            "subdirectories": true,
+            "no-autodownload": true,
+            "autodelete": true
+        },
         "org.freedesktop.Platform.VAAPI.Intel" : {
             "directory": "lib/dri/intel-vaapi-driver",
             "autodelete": false,
@@ -76,6 +83,7 @@
                  "*.la", "*.a"],
     "cleanup-commands": [ "for i in /usr/lib/*.a; do cp $i $i.tmp; strip -g $i.tmp; mv $i.tmp $i; done",
                           "mkdir -p /usr/lib/sdk",
+                          "mkdir -p /usr/bin/sdk",
                           "mkdir -p /usr/lib/GL",
                           "mkdir -p /usr/lib/debug",
                           "mkdir -p /usr/lib/ffmpeg",

--- a/org.freedesktop.Sdk.json.in
+++ b/org.freedesktop.Sdk.json.in
@@ -52,7 +52,6 @@
         },
         "org.freedesktop.Sdk.Tools": {
             "directory": "bin/sdk",
-            "add-ld-path": "lib",
             "subdirectories": true,
             "no-autodownload": true,
             "autodelete": true


### PR DESCRIPTION
This is similar to org.freedesktop.Sdk.Extension except it is intended for more general tools used by IDEs such as language servers.

This would be useful for applications like emacs, atom, vscode, etc, that are development tools using the Sdk as their runtime.

One thought I don't know the best answer to atm: To make `PATH` usage easy we want to use `merge-dirs` but I'm unsure how that deals with conflicts. A workaround could be to merge `bin/exports` so extensions will only contain clearly chosen binaries which should at least make it manageable but that comes with its own problems. Maybe it just isn't worth it?

(I've also not tested this yet, just thought feedback would be useful)