### PR TITLE
Add -fPIC to build options allowing static linking

### DIFF
--- a/org.freedesktop.Sdk.Extension.gfortran62.json.in
+++ b/org.freedesktop.Sdk.Extension.gfortran62.json.in
@@ -9,8 +9,8 @@
     "separate-locales": false,
     "cleanup": [ "/share/info", "/share/man" ],
     "build-options" : {
-        "cflags": "-O2 -g",
-        "cxxflags": "-O2 -g",
+        "cflags": "-O2 -g -fPIC",
+        "cxxflags": "-O2 -g -fPIC",
         "prefix": "/usr/lib/sdk/gfortran-62",
         "env": {
             "V": "1"


### PR DESCRIPTION
Current build breaks linking gfortran statically like in the following snipplet. Building with -fPIC solves the problem.

<pre>
{
    "name": "lapack",
    "buildsystem": "cmake",
    "builddir": true,
    "build-options": {
        "env": {
            "FFLAGS": "-O2 -fPIC",
            "LDFLAGS": "-static-libgfortran"
        }
    },
    "config-opts": [
        "-DCMAKE_BUILD_TYPE=Release",
        "-DBUILD_SHARED_LIBS=ON",
        "-DBUILD_TESTING=OFF",
        "-DLAPACKE=ON",
        "-DCBLAS=ON"
    ],
    "sources": [
        {
            "type": "archive",
            "url": "http://www.netlib.org/lapack/lapack-3.8.0.tar.gz",
            "sha512": "17786cb7306fccdc9b4a242de7f64fc261ebe6a10b6ec55f519deb4cb673cb137e8742aa5698fd2dc52f1cd56d3bd116af3f593a01dcf6770c4dcc86c50b2a7f"
        }
    ]
}
</pre>

#### Error:


> /usr/bin/ld: /usr/lib/sdk/gfortran-62/lib/gcc/x86_64-pc-linux-gnu/6.2.0/../../../../lib/libgfortran.a(stop.o): relocation R_X86_64_32 against `.rodata.report_exception.part.0.str1.8' can not be used when making a shared object; recompile with -fPIC
>
> /usr/bin/ld: /usr/lib/sdk/gfortran-62/lib/gcc/x86_64-pc-linux-gnu/6.2.0/../../../../lib/libgfortran.a(transfer.o): relocation R_X86_64_32S against `.rodata.bswap_array' can not be used when making a shared object; recompile with -fPIC
> [...]

Fix: static linking of libgfortran