### PR TITLE
Add extension point for GTK+ modules

### DIFF
--- a/org.freedesktop.Sdk.json.in
+++ b/org.freedesktop.Sdk.json.in
@@ -41,6 +41,13 @@
             "version": "3.22",
             "download-if": "active-gtk-theme"
         },
+        "org.gtk.Gtk3module" : {
+            "directory": "lib/gtk3-modules",
+            "merge-dirs": "modules",
+            "no-autodownload": true,
+            "subdirectories": true,
+            "version": "3.0"
+        },
         "org.freedesktop.Platform.ffmpeg" : {
             "directory": "lib/ffmpeg",
             "add-ld-path": "lib"
@@ -68,6 +75,7 @@
         "--extension=org.freedesktop.Platform.VAAPI.Intel=autoprune-unless=have-intel-gpu",
         "--env=GI_TYPELIB_PATH=/app/lib/girepository-1.0",
         "--env=GST_PLUGIN_SYSTEM_PATH=/app/lib/gstreamer-1.0:/usr/lib/extensions/gstreamer-1.0:/usr/lib/gstreamer-1.0",
+        "--env=GTK_PATH=/usr/lib/gtk3-modules",
         "--env=XDG_DATA_DIRS=/app/share:/usr/share:/usr/share/runtime/share:/run/host/share",
         "--sdk=org.freedesktop.Sdk//@@SDK_BRANCH@@",
         "--runtime=org.freedesktop.Platform//@@SDK_BRANCH@@"


### PR DESCRIPTION
GTK+ modules provide extra functionality to GTK+, so this patch adds
the extension point to the freedesktop Platform and Sdk runtimes,
making it easy for those modules to be used with Flatpak apps.

Extensions that have GTK+ modules should have an org.gtk.Gtk3module as
a prefix in their name.
Note that in order for the actual modules to be loaded, they have to
be added to the GTK3_MODULES environment variable (passed Flatpak when
running an app).

See motivation and discussion [here](https://gitlab.com/freedesktop-sdk/freedesktop-sdk/issues/366).