### PR TITLE
Patch to fix SIGFPE crash in libva-vdpau-driver

### DIFF
--- a/libva-vdpau-driver-0.7.4-sigfpe-crash.patch
+++ b/libva-vdpau-driver-0.7.4-sigfpe-crash.patch
@@ -1,0 +1,22 @@
+Description: Fix a crash if a heap is destroyed before being initialized
+Author: Sebastian Ramacher <sramacher@debian.org>
+Bug: https://bugs.freedesktop.org/show_bug.cgi?id=58836
+Bug-Debian: http://bugs.debian.org/748294
+Last-Update: 2014-06-02
+
+--- vdpau-video-0.7.4.orig/src/object_heap.c
++++ vdpau-video-0.7.4/src/object_heap.c
+@@ -272,8 +272,10 @@ object_heap_destroy(object_heap_p heap)
+         ASSERT(obj->next_free != ALLOCATED);
+     }
+
+-    for (i = 0; i < heap->heap_size / heap->heap_increment; i++) {
+-        free(heap->bucket[i]);
++    if (heap->bucket) {
++        for (i = 0; i < heap->heap_size / heap->heap_increment; i++) {
++            free(heap->bucket[i]);
++        }
+     }
+
+     pthread_mutex_destroy(&heap->mutex);
+

--- a/org.freedesktop.Sdk.json.in
+++ b/org.freedesktop.Sdk.json.in
@@ -1556,6 +1556,10 @@
                 {
                     "type": "patch",
                     "path": "libva-vdpau-driver-0.7.4-fix_type.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "libva-vdpau-driver-0.7.4-sigfpe-crash.patch"
                 }
             ]
         },


### PR DESCRIPTION
Fixes #126 
Patch is from debian and has been applied to 18.08. This will fix a crash running avidemux from flathub on an NVidia card.